### PR TITLE
Implement adaptive director service with debug overlay

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -247,3 +247,106 @@ button.secondary {
     align-items: flex-start;
   }
 }
+
+.scenario-run {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.run-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+}
+
+.modifier-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.modifier-list li {
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.6rem;
+  font-size: 0.85rem;
+}
+
+.timer-list {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timer-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-muted);
+}
+
+.telemetry-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.telemetry-grid ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.director-debug-overlay {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: min(340px, 90vw);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-soft);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  z-index: 20;
+}
+
+.director-debug-overlay header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.debug-section {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.debug-section dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.debug-section ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}

--- a/src/components/DirectorDebugOverlay.tsx
+++ b/src/components/DirectorDebugOverlay.tsx
@@ -1,0 +1,138 @@
+import { Fragment } from 'react'
+
+import type { DirectorDebugSnapshot, DirectorMode } from '../core/director'
+
+interface DirectorDebugOverlayProps {
+  snapshot: DirectorDebugSnapshot
+}
+
+const MODE_LABEL: Record<DirectorMode, string> = {
+  application: 'Application',
+  recall: 'Recall',
+  boss_setup: 'Boss setup',
+}
+
+const formatPercent = (value: number): string => {
+  if (!Number.isFinite(value)) {
+    return '—'
+  }
+
+  return `${Math.round(value * 100)}%`
+}
+
+const DirectorDebugOverlay = ({ snapshot }: DirectorDebugOverlayProps): JSX.Element => {
+  const distributionRows = (Object.keys(MODE_LABEL) as DirectorMode[]).map((mode) => {
+    const target = snapshot.distribution.target[mode]
+    const actual = snapshot.distribution.actual[mode]
+    const deficit = snapshot.distribution.deficits[mode]
+
+    return {
+      mode,
+      target,
+      actual,
+      deficit,
+    }
+  })
+
+  const candidates = snapshot.candidates.slice(0, 5)
+
+  return (
+    <aside className="director-debug-overlay" role="log" aria-live="polite">
+      <header>
+        <h4>Director Debug</h4>
+        <p className="small-print">Overlay {snapshot.enabled ? 'active' : 'inactive'}</p>
+      </header>
+
+      {snapshot.lastDecision ? (
+        <section className="debug-section">
+          <strong>Last decision</strong>
+          <p>
+            Day {snapshot.lastDecision.day} · {snapshot.lastDecision.difficulty.toUpperCase()} ·
+            Mode {MODE_LABEL[snapshot.lastDecision.mode]}
+            {snapshot.lastDecision.mode !== snapshot.lastDecision.intendedMode ? (
+              <span className="small-print">
+                {' '}
+                (target {MODE_LABEL[snapshot.lastDecision.intendedMode]})
+              </span>
+            ) : null}
+          </p>
+          {snapshot.lastDecision.event ? (
+            <p className="small-print">Event {snapshot.lastDecision.event.id}</p>
+          ) : (
+            <p className="small-print">No event available. Content pack may be empty.</p>
+          )}
+        </section>
+      ) : (
+        <p className="small-print">No director decisions recorded yet.</p>
+      )}
+
+      <section className="debug-section">
+        <strong>Distribution</strong>
+        <dl>
+          {distributionRows.map((row) => (
+            <Fragment key={row.mode}>
+              <dt>{MODE_LABEL[row.mode]}</dt>
+              <dd>
+                {formatPercent(row.actual)} of {formatPercent(row.target)} target
+                <span className="small-print"> · Δ {row.deficit.toFixed(2)}</span>
+              </dd>
+            </Fragment>
+          ))}
+        </dl>
+      </section>
+
+      <section className="debug-section">
+        <strong>Top candidates</strong>
+        {candidates.length > 0 ? (
+          <ol>
+            {candidates.map((candidate) => (
+              <li key={candidate.eventId}>
+                <div>
+                  <span>{candidate.eventId}</span>
+                  <span className="small-print"> · {candidate.topic}</span>
+                </div>
+                <div className="small-print">
+                  Weight {candidate.weight.toFixed(2)} · {MODE_LABEL[candidate.mode]}
+                </div>
+                <div className="small-print">
+                  {Object.entries(candidate.breakdown)
+                    .map(
+                      ([key, value]) =>
+                        `${key[0]?.toUpperCase()}${key.slice(1)}:${value.toFixed(2)}`,
+                    )
+                    .join(' ')}
+                </div>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="small-print">No candidate events were available.</p>
+        )}
+      </section>
+
+      {snapshot.lastContext ? (
+        <section className="debug-section">
+          <strong>Last context</strong>
+          <p className="small-print">
+            Mastery focus:{' '}
+            {Object.entries(snapshot.lastContext.masteryByTopic)
+              .sort(([, a], [, b]) => a - b)
+              .slice(0, 3)
+              .map(([topic, score]) => `${topic} ${(score * 100).toFixed(0)}%`)
+              .join(', ')}
+          </p>
+          <p className="small-print">
+            Mistakes tracked:{' '}
+            {snapshot.lastContext.recentMistakes.length > 0
+              ? snapshot.lastContext.recentMistakes
+                  .map((mistake) => (typeof mistake === 'string' ? mistake : mistake.topic))
+                  .join(', ')
+              : 'none'}
+          </p>
+        </section>
+      ) : null}
+    </aside>
+  )
+}
+
+export default DirectorDebugOverlay

--- a/src/core/director/index.ts
+++ b/src/core/director/index.ts
@@ -1,71 +1,605 @@
-import type { WeightedItem, RNG } from '../rng'
-import { chooseWeighted, createRNGController } from '../rng'
+import { chooseWeighted, createRNGController, type RNG, type WeightedItem } from '../rng'
+import type { MeterSnapshot, OutcomeDelta } from '../scoring'
 
 export type DirectorDifficulty = 'easy' | 'normal' | 'hard'
+export type DirectorMode = 'application' | 'recall' | 'boss_setup'
+
+export interface DirectorDifficultyCurve {
+  start: DirectorDifficulty
+  mid: DirectorDifficulty
+  late: DirectorDifficulty
+}
+
+export type DirectorMistake =
+  | string
+  | {
+      topic: string
+      timestamp?: string | number
+      eventId?: string
+    }
+
+export type DirectorMeterState = Partial<MeterSnapshot> & Record<string, number | undefined>
 
 export interface DirectorEvent {
   id: string
   topic: string
   pressure: number
   description: string
+  meterImpact?: OutcomeDelta
+  citation?: string
+  relatedQuestionId?: string
 }
 
-export interface DirectorState {
+export interface DirectorTimer {
+  id: string
+  label: string
+  durationMs: number
+}
+
+export interface DirectorPlanInput {
+  day: number
+  masteryByTopic: Record<string, number>
+  recentMistakes: readonly DirectorMistake[]
+  meterStates: DirectorMeterState
+  difficultyCurve?: DirectorDifficultyCurve
+}
+
+export interface DirectorDecision {
+  event: DirectorEvent | null
   day: number
   difficulty: DirectorDifficulty
-  rng: RNG
+  mode: DirectorMode
+  intendedMode: DirectorMode
+  modifiers: string[]
+  timers: DirectorTimer[]
+}
+
+export interface DirectorWeightBreakdown {
+  mastery: number
+  mistakes: number
+  meters: number
+  difficulty: number
+  mode: number
+  randomness: number
+}
+
+export interface DirectorDebugCandidateSnapshot {
+  eventId: string
+  topic: string
+  mode: DirectorMode
+  weight: number
+  breakdown: DirectorWeightBreakdown
+}
+
+export interface DirectorPlanContextSnapshot extends DirectorPlanInput {
+  difficultyCurve: DirectorDifficultyCurve
+}
+
+export interface DirectorDistributionSnapshot {
+  target: Record<DirectorMode, number>
+  actual: Record<DirectorMode, number>
+  deficits: Record<DirectorMode, number>
+}
+
+export interface DirectorDebugSnapshot {
+  enabled: boolean
+  counts: Record<DirectorMode, number>
+  distribution: DirectorDistributionSnapshot
+  lastDecision: DirectorDecision | null
+  lastContext: DirectorPlanContextSnapshot | null
+  intendedMode: DirectorMode | null
+  candidates: DirectorDebugCandidateSnapshot[]
+}
+
+export interface DirectorRuntimeState {
+  counts: Record<DirectorMode, number>
+  lastEventId: string | null
+  lastDecision: DirectorDecision | null
+  lastContext: DirectorPlanContextSnapshot | null
+  intendedMode: DirectorMode | null
+  debugEnabled: boolean
+  candidates: DirectorCandidateInsight[]
 }
 
 export interface DirectorConfig {
-  startDifficulty: DirectorDifficulty
+  events: readonly DirectorEvent[]
+  difficultyCurve: DirectorDifficultyCurve
   seed?: number
 }
 
-export const createDirector = (config: DirectorConfig): DirectorState => {
-  const controller = createRNGController(config.seed)
+export type DirectorDebugAction = 'toggle' | 'peek'
 
-  return {
-    day: 1,
-    difficulty: config.startDifficulty,
-    rng: controller.next,
-  }
+export interface DirectorService {
+  planNext: (input: DirectorPlanInput) => DirectorDecision
+  debug: (action?: DirectorDebugAction) => DirectorDebugSnapshot
+  getState: () => DirectorRuntimeState
 }
 
-export const planEvents = <T extends DirectorEvent>(
-  events: readonly T[],
-  state: DirectorState,
-): T | null => {
-  if (events.length === 0) {
-    return null
-  }
-
-  const weighted: WeightedItem<T>[] = events.map((event) => ({
-    value: event,
-    weight: Math.max(1, 5 - Math.abs(event.pressure - state.day)),
-  }))
-
-  return chooseWeighted(weighted, state.rng)
+interface DirectorCandidateInsight {
+  event: DirectorEvent
+  weight: number
+  mode: DirectorMode
+  breakdown: DirectorWeightBreakdown
 }
 
-export const advanceDirector = (
-  state: DirectorState,
-  outcome: 'success' | 'failure',
-): DirectorState => {
-  const nextDifficulty: DirectorDifficulty = (() => {
-    if (outcome === 'success') {
-      if (state.difficulty === 'easy') return 'normal'
-      if (state.difficulty === 'normal') return 'hard'
-      return 'hard'
+const TARGET_DISTRIBUTION: Record<DirectorMode, number> = {
+  application: 0.7,
+  recall: 0.2,
+  boss_setup: 0.1,
+}
+
+const DIFFICULTY_PRESSURE_TARGET: Record<DirectorDifficulty, number> = {
+  easy: 1.5,
+  normal: 2.8,
+  hard: 4.2,
+}
+
+const BASE_WEIGHT = 0.6
+const MIN_WEIGHT = 0.01
+
+const determinePhase = (day: number): keyof DirectorDifficultyCurve => {
+  if (day <= 3) return 'start'
+  if (day <= 7) return 'mid'
+  return 'late'
+}
+
+const resolveDifficulty = (curve: DirectorDifficultyCurve, day: number): DirectorDifficulty => {
+  return curve[determinePhase(day)]
+}
+
+const normalizeMastery = (value: number | undefined): number => {
+  if (value === undefined) {
+    return 0.5
+  }
+
+  if (Number.isNaN(value)) {
+    return 0.5
+  }
+
+  if (value > 1) {
+    return Math.max(0, Math.min(1, value / 100))
+  }
+
+  return Math.max(0, Math.min(1, value))
+}
+
+const normalizeMistake = (entry: DirectorMistake): { topic: string } | null => {
+  if (typeof entry === 'string') {
+    return entry ? { topic: entry } : null
+  }
+
+  if (entry && entry.topic) {
+    return { topic: entry.topic }
+  }
+
+  return null
+}
+
+const countMistakes = (mistakes: readonly DirectorMistake[]): Record<string, number> => {
+  return mistakes.reduce<Record<string, number>>((acc, raw) => {
+    const normalized = normalizeMistake(raw)
+
+    if (!normalized) {
+      return acc
     }
 
-    if (state.difficulty === 'hard') return 'normal'
-    if (state.difficulty === 'normal') return 'easy'
-    return 'easy'
-  })()
+    acc[normalized.topic] = (acc[normalized.topic] ?? 0) + 1
+    return acc
+  }, {})
+}
+
+const evaluateMeterAlignment = (event: DirectorEvent, meterStates: DirectorMeterState): number => {
+  if (!event.meterImpact) {
+    return 0
+  }
+
+  const { meterImpact } = event
+  let score = 0
+  const target = 60
+
+  for (const [meter, impact] of Object.entries(meterImpact)) {
+    if (meter === 'summary' || typeof impact !== 'number') {
+      continue
+    }
+
+    const current = meterStates[meter] ?? target
+
+    if (impact > 0) {
+      const deficit = Math.max(0, target - current) / target
+      score += deficit * (Math.abs(impact) / 5)
+    } else if (impact < 0) {
+      const surplus = Math.max(0, current - target) / target
+      score += surplus * (Math.abs(impact) / 5) * 0.75
+    }
+  }
+
+  return score
+}
+
+const evaluateDifficultyAlignment = (
+  event: DirectorEvent,
+  difficulty: DirectorDifficulty,
+): number => {
+  const targetPressure = DIFFICULTY_PRESSURE_TARGET[difficulty]
+  const gap = Math.abs(event.pressure - targetPressure)
+  const scale = Math.max(1, targetPressure)
+  const closeness = Math.max(0, 1 - gap / scale)
+
+  return closeness
+}
+
+const classifyEvent = (event: DirectorEvent): DirectorMode => {
+  if (event.id.includes('boss') || event.topic.toLowerCase().includes('boss')) {
+    return 'boss_setup'
+  }
+
+  if (event.pressure >= 4) {
+    return 'boss_setup'
+  }
+
+  if (event.relatedQuestionId) {
+    return 'application'
+  }
+
+  return 'recall'
+}
+
+const pickMode = (counts: Record<DirectorMode, number>, totalDecisions: number): DirectorMode => {
+  let bestMode: DirectorMode = 'application'
+  let bestDeficit = -Infinity(Object.keys(TARGET_DISTRIBUTION) as DirectorMode[]).forEach(
+    (mode) => {
+      const targetCount = TARGET_DISTRIBUTION[mode] * (totalDecisions + 1)
+      const current = counts[mode]
+      const deficit = targetCount - current
+
+      if (deficit > bestDeficit) {
+        bestMode = mode
+        bestDeficit = deficit
+      }
+    },
+  )
+
+  return bestMode
+}
+
+const clampMeters = (snapshot: DirectorMeterState): DirectorMeterState => {
+  const next: DirectorMeterState = { ...snapshot }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (typeof value !== 'number') continue
+    next[key] = Math.max(0, Math.min(100, Math.round(value)))
+  }
+
+  return next
+}
+
+const buildCandidates = (
+  events: readonly DirectorEvent[],
+  runtime: DirectorRuntimeState,
+  context: DirectorPlanContextSnapshot,
+  intendedMode: DirectorMode,
+  difficulty: DirectorDifficulty,
+  rng: RNG,
+): DirectorCandidateInsight[] => {
+  const mistakesByTopic = countMistakes(context.recentMistakes)
+  const totalMistakes = context.recentMistakes.length
+  const availableEvents = events.filter((event) => {
+    if (events.length === 1) {
+      return true
+    }
+
+    return event.id !== runtime.lastEventId
+  })
+
+  const candidates = (
+    availableEvents.length > 0 ? availableEvents : events
+  ).map<DirectorCandidateInsight>((event) => {
+    const mode = classifyEvent(event)
+    const mastery = normalizeMastery(context.masteryByTopic[event.topic])
+    const masteryGap = 1 - mastery
+    const masteryContribution = masteryGap * 1.8
+
+    const mistakesForTopic = mistakesByTopic[event.topic] ?? 0
+    const mistakeShare = totalMistakes === 0 ? 0 : mistakesForTopic / totalMistakes
+    const mistakeContribution = mistakesForTopic > 0 ? 0.6 + mistakeShare * 1.2 : 0
+
+    const meterContribution = evaluateMeterAlignment(event, context.meterStates)
+    const difficultyContribution = evaluateDifficultyAlignment(event, difficulty)
+    const modeMultiplier = mode === intendedMode ? 1.35 : 0.85
+    const randomness = rng() * 0.25
+
+    const rawWeight =
+      (BASE_WEIGHT +
+        masteryContribution +
+        mistakeContribution +
+        meterContribution +
+        difficultyContribution) *
+        modeMultiplier +
+      randomness
+
+    const weight = Math.max(MIN_WEIGHT, rawWeight)
+
+    return {
+      event,
+      mode,
+      weight,
+      breakdown: {
+        mastery: masteryContribution,
+        mistakes: mistakeContribution,
+        meters: meterContribution,
+        difficulty: difficultyContribution,
+        mode: modeMultiplier,
+        randomness,
+      },
+    }
+  })
+
+  return candidates
+}
+
+const modifierCatalog: {
+  id: string
+  label: string
+  condition: (context: DirectorPlanContextSnapshot, event: DirectorEvent | null) => boolean
+}[] = [
+  {
+    id: 'modifier.rent-control',
+    label: 'Municipal Rent Control in effect',
+    condition: (context) => {
+      const ownerRoi = context.meterStates.ownerROI
+      return typeof ownerRoi === 'number' && ownerRoi < 55
+    },
+  },
+  {
+    id: 'modifier.voucher-inspection',
+    label: 'Voucher Inspection this week',
+    condition: (context) => {
+      const compliance = context.meterStates.compliance ?? 100
+      if (compliance < 60) return true
+      return context.recentMistakes.some((mistake) => {
+        const normalized = normalizeMistake(mistake)
+        return normalized?.topic.toLowerCase().includes('njlad') ?? false
+      })
+    },
+  },
+  {
+    id: 'modifier.court-backlog',
+    label: 'Housing Court Backlog slowing filings',
+    condition: (context) => context.day % 5 === 0,
+  },
+  {
+    id: 'modifier.community-pressure',
+    label: 'Community Advocacy Spotlight hits the property',
+    condition: (context, event) => {
+      if (event?.topic.toLowerCase().includes('njlad')) return true
+      const trust = context.meterStates.residentTrust ?? 70
+      return trust < 50
+    },
+  },
+]
+
+const buildModifiers = (
+  context: DirectorPlanContextSnapshot,
+  event: DirectorEvent | null,
+  rng: RNG,
+): string[] => {
+  const active = modifierCatalog.filter((modifier) => modifier.condition(context, event))
+
+  if (active.length === 0) {
+    return rng() > 0.6 ? ['Regional Policy Brief Released'] : []
+  }
+
+  const shuffled = active
+    .map<[number, string]>((modifier) => [rng(), modifier.label])
+    .sort((a, b) => a[0] - b[0])
+    .map(([, label]) => label)
+
+  return shuffled.slice(0, 2)
+}
+
+const BASE_TIMER: Record<DirectorDifficulty, number> = {
+  easy: 120_000,
+  normal: 95_000,
+  hard: 75_000,
+}
+
+const buildTimers = (
+  difficulty: DirectorDifficulty,
+  event: DirectorEvent | null,
+  mode: DirectorMode,
+  rng: RNG,
+  recentMistakeCount: number,
+): DirectorTimer[] => {
+  const base = BASE_TIMER[difficulty]
+  const pressure = event?.pressure ?? 0
+  const pressureAdjustment = pressure * 6_000
+  const mistakeAdjustment = Math.min(20_000, recentMistakeCount * 2_500)
+
+  const responseWindow = Math.max(45_000, base - pressureAdjustment + mistakeAdjustment)
+  const reviewWindow = base + 30_000 + Math.round(rng() * 15_000)
+
+  const timers: DirectorTimer[] = [
+    {
+      id: 'timer.response',
+      label: 'Response Window',
+      durationMs: Math.round(responseWindow),
+    },
+    {
+      id: 'timer.review',
+      label: 'Follow-up Review',
+      durationMs: Math.round(reviewWindow),
+    },
+  ]
+
+  if (mode === 'boss_setup') {
+    timers.push({
+      id: 'timer.boss-prep',
+      label: 'Boss Case Prep Countdown',
+      durationMs: base + 60_000,
+    })
+  }
+
+  return timers
+}
+
+const computeDistribution = (
+  counts: Record<DirectorMode, number>,
+): DirectorDistributionSnapshot => {
+  const total = (Object.values(counts) as number[]).reduce((sum, value) => sum + value, 0)
+
+  const actual = (Object.keys(counts) as DirectorMode[]).reduce<Record<DirectorMode, number>>(
+    (acc, mode) => {
+      acc[mode] = total === 0 ? 0 : counts[mode] / total
+      return acc
+    },
+    { application: 0, recall: 0, boss_setup: 0 },
+  )
+
+  const deficits = (Object.keys(TARGET_DISTRIBUTION) as DirectorMode[]).reduce<
+    Record<DirectorMode, number>
+  >(
+    (acc, mode) => {
+      const targetCount = TARGET_DISTRIBUTION[mode] * (total + 1)
+      acc[mode] = targetCount - counts[mode]
+      return acc
+    },
+    { application: 0, recall: 0, boss_setup: 0 },
+  )
+
+  return { target: TARGET_DISTRIBUTION, actual, deficits }
+}
+
+const createDebugSnapshot = (state: DirectorRuntimeState): DirectorDebugSnapshot => {
+  const candidates = state.candidates
+    .map<DirectorDebugCandidateSnapshot>((candidate) => ({
+      eventId: candidate.event.id,
+      topic: candidate.event.topic,
+      mode: candidate.mode,
+      weight: candidate.weight,
+      breakdown: candidate.breakdown,
+    }))
+    .sort((a, b) => b.weight - a.weight)
 
   return {
-    ...state,
-    day: state.day + 1,
-    difficulty: nextDifficulty,
+    enabled: state.debugEnabled,
+    counts: { ...state.counts },
+    distribution: computeDistribution(state.counts),
+    lastDecision: state.lastDecision,
+    lastContext: state.lastContext,
+    intendedMode: state.intendedMode,
+    candidates,
+  }
+}
+
+export const createDirector = (config: DirectorConfig): DirectorService => {
+  const controller = createRNGController(config.seed)
+  const rng = controller.next
+
+  const runtime: DirectorRuntimeState = {
+    counts: { application: 0, recall: 0, boss_setup: 0 },
+    lastEventId: null,
+    lastDecision: null,
+    lastContext: null,
+    intendedMode: null,
+    debugEnabled: false,
+    candidates: [],
+  }
+
+  const planNext = (input: DirectorPlanInput): DirectorDecision => {
+    const day = Math.max(1, Math.floor(input.day))
+    const difficultyCurve = input.difficultyCurve ?? config.difficultyCurve
+    const difficulty = resolveDifficulty(difficultyCurve, day)
+    const totalDecisions = (Object.values(runtime.counts) as number[]).reduce(
+      (sum, value) => sum + value,
+      0,
+    )
+    const intendedMode = pickMode(runtime.counts, totalDecisions)
+
+    const context: DirectorPlanContextSnapshot = {
+      ...input,
+      day,
+      masteryByTopic: { ...input.masteryByTopic },
+      meterStates: clampMeters(input.meterStates),
+      recentMistakes: [...input.recentMistakes],
+      difficultyCurve,
+    }
+
+    const candidates = buildCandidates(
+      config.events,
+      runtime,
+      context,
+      intendedMode,
+      difficulty,
+      rng,
+    )
+    runtime.candidates = candidates
+
+    let selection: DirectorCandidateInsight | null = null
+
+    if (candidates.length > 0) {
+      const weighted: WeightedItem<DirectorCandidateInsight>[] = candidates.map((candidate) => ({
+        value: candidate,
+        weight: candidate.weight,
+      }))
+
+      selection = chooseWeighted(weighted, rng)
+    }
+
+    const selectedEvent = selection?.event ?? null
+    const actualMode = selectedEvent ? classifyEvent(selectedEvent) : intendedMode
+
+    if (selectedEvent) {
+      runtime.lastEventId = selectedEvent.id
+      runtime.counts[actualMode] += 1
+    }
+
+    const modifiers = buildModifiers(context, selectedEvent, rng)
+    const timers = buildTimers(
+      difficulty,
+      selectedEvent,
+      actualMode,
+      rng,
+      context.recentMistakes.length,
+    )
+
+    const decision: DirectorDecision = {
+      event: selectedEvent,
+      day,
+      difficulty,
+      mode: actualMode,
+      intendedMode,
+      modifiers,
+      timers,
+    }
+
+    runtime.lastDecision = decision
+    runtime.lastContext = context
+    runtime.intendedMode = intendedMode
+
+    return decision
+  }
+
+  const debug = (action: DirectorDebugAction = 'toggle'): DirectorDebugSnapshot => {
+    if (action === 'toggle') {
+      runtime.debugEnabled = !runtime.debugEnabled
+    }
+
+    return createDebugSnapshot(runtime)
+  }
+
+  const getState = (): DirectorRuntimeState => ({
+    counts: { ...runtime.counts },
+    lastEventId: runtime.lastEventId,
+    lastDecision: runtime.lastDecision,
+    lastContext: runtime.lastContext,
+    intendedMode: runtime.intendedMode,
+    debugEnabled: runtime.debugEnabled,
+    candidates: [...runtime.candidates],
+  })
+
+  return {
+    planNext,
+    debug,
+    getState,
   }
 }

--- a/src/pages/RunPage.tsx
+++ b/src/pages/RunPage.tsx
@@ -1,26 +1,223 @@
-import { createDirector, planEvents } from '../core/director'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import DirectorDebugOverlay from '../components/DirectorDebugOverlay'
+import {
+  createDirector,
+  type DirectorDecision,
+  type DirectorDebugSnapshot,
+  type DirectorMistake,
+} from '../core/director'
+import { defaultMeters, type MeterSnapshot } from '../core/scoring'
 import { useActivePack } from '../data/packs'
 
-const RunPage = () => {
+const clamp = (value: number, min = 0, max = 1): number => {
+  return Math.min(max, Math.max(min, value))
+}
+
+const RunPage = (): JSX.Element => {
   const pack = useActivePack()
-  const director = createDirector({ startDifficulty: pack.difficultyCurve.start })
-  const nextEvent = planEvents(pack.events, director)
+
+  const director = useMemo(
+    () =>
+      createDirector({
+        events: pack.events,
+        difficultyCurve: pack.difficultyCurve,
+      }),
+    [pack],
+  )
+
+  const [day, setDay] = useState(1)
+  const [masteryByTopic, setMasteryByTopic] = useState<Record<string, number>>({})
+  const [meterStates, setMeterStates] = useState<Record<string, number>>({})
+  const [recentMistakes, setRecentMistakes] = useState<DirectorMistake[]>([])
+  const [decision, setDecision] = useState<DirectorDecision | null>(null)
+  const [debugSnapshot, setDebugSnapshot] = useState<DirectorDebugSnapshot | null>(null)
+
+  useEffect(() => {
+    setDay(1)
+    setMasteryByTopic(() =>
+      pack.topics.reduce<Record<string, number>>((acc, topic, index) => {
+        const baseline = clamp(0.8 - index * 0.1)
+        acc[topic] = Number(baseline.toFixed(2))
+        return acc
+      }, {}),
+    )
+    setMeterStates(() => ({ ...defaultMeters }))
+    setRecentMistakes(() =>
+      pack.topics.slice(0, 2).map((topic, index) => ({
+        topic,
+        timestamp: new Date(Date.now() - index * 45 * 60 * 1000).toISOString(),
+      })),
+    )
+  }, [pack])
+
+  useEffect(() => {
+    const nextDecision = director.planNext({
+      day,
+      masteryByTopic,
+      recentMistakes,
+      meterStates,
+      difficultyCurve: pack.difficultyCurve,
+    })
+
+    setDecision(nextDecision)
+  }, [director, day, masteryByTopic, meterStates, recentMistakes, pack.difficultyCurve])
+
+  useEffect(() => {
+    if (debugSnapshot?.enabled) {
+      setDebugSnapshot(director.debug('peek'))
+    }
+  }, [director, decision, debugSnapshot?.enabled])
+
+  const handleAdvanceDay = useCallback(() => {
+    setDay((current) => current + 1)
+
+    setMasteryByTopic((current) => {
+      if (!decision?.event) {
+        return current
+      }
+
+      const next = { ...current }
+      const existing = next[decision.event.topic] ?? 0.5
+      next[decision.event.topic] = Number(clamp(existing + 0.05).toFixed(2))
+      return next
+    })
+
+    setMeterStates((current) => {
+      if (!decision?.event?.meterImpact) {
+        return current
+      }
+
+      const next = { ...current }
+
+      for (const [meter, impact] of Object.entries(decision.event.meterImpact)) {
+        if (meter === 'summary' || typeof impact !== 'number') {
+          continue
+        }
+
+        const baseline =
+          current[meter] ?? (defaultMeters as MeterSnapshot)[meter as keyof MeterSnapshot] ?? 60
+        next[meter] = Math.max(0, Math.min(100, Math.round(baseline + impact * 2)))
+      }
+
+      return next
+    })
+
+    if (decision?.event) {
+      setRecentMistakes((current) => {
+        const entry: DirectorMistake = {
+          topic: decision.event!.topic,
+          eventId: decision.event!.id,
+          timestamp: new Date().toISOString(),
+        }
+
+        return [...current.slice(-4), entry]
+      })
+    }
+  }, [decision])
+
+  const handleToggleDebug = useCallback(() => {
+    const snapshot = director.debug()
+    setDebugSnapshot(snapshot.enabled ? snapshot : null)
+  }, [director])
 
   return (
-    <section>
-      <h2>Scenario Run</h2>
-      {nextEvent ? (
+    <section className="scenario-run">
+      <header className="run-header">
+        <div>
+          <h2>Scenario Director</h2>
+          <p className="small-print">
+            Day {day} · Active difficulty {decision?.difficulty ?? pack.difficultyCurve.start}
+          </p>
+        </div>
+        <div className="button-row">
+          <button type="button" onClick={handleAdvanceDay}>
+            Advance simulation day
+          </button>
+          <button type="button" className="secondary" onClick={handleToggleDebug}>
+            Toggle debug overlay
+          </button>
+        </div>
+      </header>
+
+      {decision?.event ? (
         <article className="card">
           <header>
-            <h3>{nextEvent.topic}</h3>
-            <p className="badge">Pressure {nextEvent.pressure}</p>
+            <h3>{decision.event.topic}</h3>
+            <p className="badge">Pressure {decision.event.pressure}</p>
           </header>
-          <p>{nextEvent.description}</p>
-          {nextEvent.citation ? <p className="small-print">Source: {nextEvent.citation}</p> : null}
+          <p>{decision.event.description}</p>
+          <p className="small-print">
+            Mode {decision.mode} · Target {decision.intendedMode}
+            {decision.event.citation ? ` · Source: ${decision.event.citation}` : ''}
+          </p>
+
+          {decision.modifiers.length > 0 ? (
+            <ul className="modifier-list">
+              {decision.modifiers.map((modifier) => (
+                <li key={modifier}>{modifier}</li>
+              ))}
+            </ul>
+          ) : null}
+
+          {decision.timers.length > 0 ? (
+            <ul className="timer-list">
+              {decision.timers.map((timer) => (
+                <li key={timer.id}>
+                  <span>{timer.label}</span>
+                  <span className="small-print">{Math.round(timer.durationMs / 1000)}s</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
         </article>
       ) : (
         <p>No events available. Add more content packs to keep the campaign fresh.</p>
       )}
+
+      <section className="card">
+        <h3>Player telemetry</h3>
+        <div className="telemetry-grid">
+          <div>
+            <h4>Mastery</h4>
+            <ul>
+              {Object.entries(masteryByTopic).map(([topic, score]) => (
+                <li key={topic}>
+                  {topic}
+                  <span className="small-print"> {(score * 100).toFixed(0)}%</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4>Meters</h4>
+            <ul>
+              {Object.entries(meterStates).map(([meter, value]) => (
+                <li key={meter}>
+                  {meter}
+                  <span className="small-print"> {value}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4>Recent mistakes</h4>
+            <ul>
+              {recentMistakes.length > 0 ? (
+                recentMistakes.map((mistake, index) => (
+                  <li key={`${typeof mistake === 'string' ? mistake : mistake.topic}-${index}`}>
+                    {typeof mistake === 'string' ? mistake : mistake.topic}
+                  </li>
+                ))
+              ) : (
+                <li>None tracked</li>
+              )}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {debugSnapshot?.enabled ? <DirectorDebugOverlay snapshot={debugSnapshot} /> : null}
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- replace the director core service with an adaptive planner that accounts for mastery, mistakes, meters, day, and difficulty curves
- generate event modifiers, dynamic timers, and distribution-balanced mode selection while preventing repeated stems
- add a reusable director debug overlay component and wire it into the run page with updated telemetry UI

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1569215c883208a6f0b8f452138eb