### PR TITLE
Fix GitHub Pages base path handling

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="refresh" content="0; url=/" />
+    <meta http-equiv="refresh" content="0; url=./" />
     <title>Redirecting…</title>
     <script>
-      window.location.replace('/')
+      window.location.replace('./')
     </script>
   </head>
   <body>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <PacksProvider>
       <CampaignStateProvider>
-        <BrowserRouter>
+        <BrowserRouter basename={import.meta.env.BASE_URL}>
           <App />
         </BrowserRouter>
       </CampaignStateProvider>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
+  base: '/Landlord-Tenant-Law/',
   plugins: [
     react(),
     VitePWA({
@@ -10,7 +11,7 @@ export default defineConfig({
       includeAssets: ['vite.svg'],
       manifest: false,
       workbox: {
-        navigateFallback: '/index.html',
+        navigateFallback: 'index.html',
         globPatterns: ['**/*.{js,css,html,svg,webmanifest}'],
       },
     }),


### PR DESCRIPTION
## Summary
- configure Vite to emit assets for the Landlord-Tenant-Law GitHub Pages subpath
- ensure the router and SPA fallback respect the configured base URL

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1729c307883208000c709110a781f