### PR TITLE
Refactor game state store to remove zustand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.9.1",
-        "zod": "^4.1.11",
-        "zustand": "^5.0.8"
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -3069,7 +3068,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4056,7 +4055,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -9937,35 +9936,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
-      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.9.1",
-    "zod": "^4.1.11",
-    "zustand": "^5.0.8"
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/core/gameState.ts
+++ b/src/core/gameState.ts
@@ -1,5 +1,5 @@
-import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { useCallback, useSyncExternalStore } from 'react'
+
 import { defaultMeters } from './scoring'
 import { createSeededRNG, type RNG } from '../utils/rand'
 
@@ -70,6 +70,10 @@ interface GameStateActions {
 export type GameStateStore = GameStateSnapshot & {
   rng: RNG
 }
+
+type GameStateData = GameStateStore
+
+export type GameStateValue = GameStateStore & GameStateActions
 
 export const toGameMeters = (snapshot: {
   compliance: number
@@ -171,284 +175,343 @@ const createRunId = (): string => {
 
 const isBrowser = typeof window !== 'undefined'
 
-let hydrateSnapshot: ((snapshot: GameStateSnapshot) => void) | undefined
+const listeners = new Set<() => void>()
 
-export const useGameState = create<GameStateStore & GameStateActions>()(
-  persist(
-    (set, get) => {
-      const applySnapshot = (snapshot: GameStateSnapshot) => {
-        const seed =
-          Math.max(0, Math.floor(snapshot.runSeed)) || Math.floor(Math.random() * 1_000_000)
-        const runId = snapshot.runId && snapshot.runId.length > 0 ? snapshot.runId : createRunId()
+let data: GameStateData = {
+  ...createDefaultSnapshot(),
+  rng: createSeededRNG(),
+}
 
-        set({
-          day: Math.max(1, Math.round(snapshot.day)),
-          runId,
-          runSeed: seed,
-          coins: Math.max(0, Math.round(snapshot.coins)),
-          xp: Math.max(0, Math.round(snapshot.xp)),
-          meters: normalizeMeters(snapshot.meters),
-          skills: normalizeStringArray(snapshot.skills),
-          badges: normalizeStringArray(snapshot.badges),
-          inventory: normalizeStringArray(snapshot.inventory),
-          mastery: normalizeMastery(snapshot.mastery),
-          streakDays: Math.max(0, Math.round(snapshot.streakDays)),
-          hintsUsed: Math.max(0, Math.round(snapshot.hintsUsed)),
-          rng: createSeededRNG(seed),
-        })
+const notify = () => {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+const partialize = (state: GameStateData): GameStateSnapshot => ({
+  day: state.day,
+  runId: state.runId,
+  runSeed: state.runSeed,
+  coins: state.coins,
+  xp: state.xp,
+  meters: state.meters,
+  skills: state.skills,
+  badges: state.badges,
+  inventory: state.inventory,
+  mastery: state.mastery,
+  streakDays: state.streakDays,
+  hintsUsed: state.hintsUsed,
+})
+
+const persistState = () => {
+  if (!isBrowser) {
+    return
+  }
+
+  try {
+    const snapshot = partialize(data)
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
+  } catch (error) {
+    console.warn('Failed to persist game state', error)
+  }
+}
+
+type PartialOrUpdater =
+  | Partial<GameStateData>
+  | ((current: GameStateData) => Partial<GameStateData> | void | GameStateData)
+
+const setData = (updater: PartialOrUpdater) => {
+  const partial = typeof updater === 'function' ? updater(data) : updater
+
+  if (!partial) {
+    return
+  }
+
+  const nextData: GameStateData = { ...data }
+  let hasChange = false
+
+  const target = nextData as Record<keyof GameStateData, GameStateData[keyof GameStateData]>
+
+  for (const [key, value] of Object.entries(partial) as [
+    keyof GameStateData,
+    GameStateData[keyof GameStateData],
+  ][]) {
+    if (!Object.is(target[key], value)) {
+      target[key] = value
+      hasChange = true
+    }
+  }
+
+  if (!hasChange) {
+    return
+  }
+
+  data = nextData
+  persistState()
+  notify()
+}
+
+const applySnapshot = (snapshot: GameStateSnapshot) => {
+  const seed = Math.max(0, Math.floor(snapshot.runSeed)) || Math.floor(Math.random() * 1_000_000)
+  const runId = snapshot.runId && snapshot.runId.length > 0 ? snapshot.runId : createRunId()
+
+  setData({
+    day: Math.max(1, Math.round(snapshot.day)),
+    runId,
+    runSeed: seed,
+    coins: Math.max(0, Math.round(snapshot.coins)),
+    xp: Math.max(0, Math.round(snapshot.xp)),
+    meters: normalizeMeters(snapshot.meters),
+    skills: normalizeStringArray(snapshot.skills),
+    badges: normalizeStringArray(snapshot.badges),
+    inventory: normalizeStringArray(snapshot.inventory),
+    mastery: normalizeMastery(snapshot.mastery),
+    streakDays: Math.max(0, Math.round(snapshot.streakDays)),
+    hintsUsed: Math.max(0, Math.round(snapshot.hintsUsed)),
+    rng: createSeededRNG(seed),
+  })
+}
+
+const createSnapshotFromData = (): GameStateSnapshot => ({
+  day: data.day,
+  runId: data.runId,
+  runSeed: data.runSeed,
+  coins: data.coins,
+  xp: data.xp,
+  meters: { ...data.meters },
+  skills: [...data.skills],
+  badges: [...data.badges],
+  inventory: [...data.inventory],
+  mastery: Object.fromEntries(
+    Object.entries(data.mastery).map(([topic, stats]) => [topic, { ...stats }]),
+  ),
+  streakDays: data.streakDays,
+  hintsUsed: data.hintsUsed,
+})
+
+const actions: GameStateActions = {
+  startRun: (seed?: number) => {
+    const actualSeed =
+      typeof seed === 'number' && Number.isFinite(seed)
+        ? Math.floor(seed)
+        : Math.floor(Math.random() * 1_000_000)
+    const base = createDefaultSnapshot()
+
+    setData({
+      ...base,
+      runId: createRunId(),
+      runSeed: actualSeed,
+      rng: createSeededRNG(actualSeed),
+      meters: normalizeMeters(base.meters),
+      skills: [...base.skills],
+      badges: [...base.badges],
+      inventory: [...base.inventory],
+      mastery: { ...base.mastery },
+    })
+
+    return actualSeed
+  },
+  setDay: (day: number) => {
+    setData({ day: Math.max(1, Math.round(day)) })
+  },
+  advanceDay: () => {
+    setData((state) => ({ day: state.day + 1 }))
+  },
+  setXp: (xp: number) => {
+    setData({ xp: Math.max(0, Math.round(xp)) })
+  },
+  addXp: (delta: number) => {
+    setData((state) => ({ xp: Math.max(0, state.xp + delta) }))
+  },
+  setCoins: (coins: number) => {
+    setData({ coins: Math.max(0, Math.round(coins)) })
+  },
+  adjustCoins: (delta: number) => {
+    setData((state) => ({ coins: Math.max(0, state.coins + delta) }))
+  },
+  setMeters: (meters: GameMeters) => {
+    setData({ meters: normalizeMeters(meters) })
+  },
+  updateMeter: (meter: keyof GameMeters, value: number) => {
+    setData((state) => ({
+      meters: {
+        ...state.meters,
+        [meter]: Math.max(0, Math.round(value)),
+      },
+    }))
+  },
+  setSkills: (skills: string[]) => {
+    setData({ skills: normalizeStringArray(skills) })
+  },
+  unlockSkill: (skillId: string) => {
+    if (typeof skillId !== 'string') {
+      return
+    }
+
+    setData((state) => {
+      const skills = state.skills.includes(skillId) ? state.skills : [...state.skills, skillId]
+
+      return { skills }
+    })
+  },
+  setBadges: (badges: string[]) => {
+    setData({ badges: normalizeStringArray(badges) })
+  },
+  addBadge: (badgeId: string) => {
+    if (typeof badgeId !== 'string') {
+      return
+    }
+
+    setData((state) => {
+      const badges = state.badges.includes(badgeId) ? state.badges : [...state.badges, badgeId]
+
+      return { badges }
+    })
+  },
+  setInventory: (items: string[]) => {
+    setData({ inventory: normalizeStringArray(items) })
+  },
+  addInventoryItem: (item: string) => {
+    if (typeof item !== 'string') {
+      return
+    }
+
+    setData((state) => {
+      const inventory = state.inventory.includes(item)
+        ? state.inventory
+        : [...state.inventory, item]
+
+      return { inventory }
+    })
+  },
+  removeInventoryItem: (item: string) => {
+    setData((state) => ({
+      inventory: state.inventory.filter((entry) => entry !== item),
+    }))
+  },
+  setMastery: (mastery: MasteryRecord) => {
+    setData({ mastery: normalizeMastery(mastery) })
+  },
+  recordMastery: (topic: string, correct: boolean) => {
+    if (typeof topic !== 'string' || topic.length === 0) {
+      return
+    }
+
+    setData((state) => {
+      const current = state.mastery[topic] ?? { right: 0, wrong: 0 }
+      const next: MasteryStats = {
+        right: current.right + (correct ? 1 : 0),
+        wrong: current.wrong + (correct ? 0 : 1),
       }
-
-      hydrateSnapshot = applySnapshot
 
       return {
-        ...createDefaultSnapshot(),
-        rng: createSeededRNG(),
-        startRun: (seed?: number) => {
-          const actualSeed =
-            typeof seed === 'number' && Number.isFinite(seed)
-              ? Math.floor(seed)
-              : Math.floor(Math.random() * 1_000_000)
-          const base = createDefaultSnapshot()
-
-          set({
-            ...base,
-            runId: createRunId(),
-            runSeed: actualSeed,
-            rng: createSeededRNG(actualSeed),
-            meters: normalizeMeters(base.meters),
-            skills: [...base.skills],
-            badges: [...base.badges],
-            inventory: [...base.inventory],
-            mastery: { ...base.mastery },
-          })
-
-          return actualSeed
-        },
-        setDay: (day: number) => {
-          set({ day: Math.max(1, Math.round(day)) })
-        },
-        advanceDay: () => {
-          set((state) => ({ day: state.day + 1 }))
-        },
-        setXp: (xp: number) => {
-          set({ xp: Math.max(0, Math.round(xp)) })
-        },
-        addXp: (delta: number) => {
-          set((state) => ({ xp: Math.max(0, state.xp + delta) }))
-        },
-        setCoins: (coins: number) => {
-          set({ coins: Math.max(0, Math.round(coins)) })
-        },
-        adjustCoins: (delta: number) => {
-          set((state) => ({ coins: Math.max(0, state.coins + delta) }))
-        },
-        setMeters: (meters: GameMeters) => {
-          set({ meters: normalizeMeters(meters) })
-        },
-        updateMeter: (meter: keyof GameMeters, value: number) => {
-          set((state) => ({
-            meters: {
-              ...state.meters,
-              [meter]: Math.max(0, Math.round(value)),
-            },
-          }))
-        },
-        setSkills: (skills: string[]) => {
-          set({ skills: normalizeStringArray(skills) })
-        },
-        unlockSkill: (skillId: string) => {
-          if (typeof skillId !== 'string') {
-            return
-          }
-
-          set((state) => {
-            const skills = state.skills.includes(skillId)
-              ? state.skills
-              : [...state.skills, skillId]
-
-            return { skills }
-          })
-        },
-        setBadges: (badges: string[]) => {
-          set({ badges: normalizeStringArray(badges) })
-        },
-        addBadge: (badgeId: string) => {
-          if (typeof badgeId !== 'string') {
-            return
-          }
-
-          set((state) => {
-            const badges = state.badges.includes(badgeId)
-              ? state.badges
-              : [...state.badges, badgeId]
-
-            return { badges }
-          })
-        },
-        setInventory: (items: string[]) => {
-          set({ inventory: normalizeStringArray(items) })
-        },
-        addInventoryItem: (item: string) => {
-          if (typeof item !== 'string') {
-            return
-          }
-
-          set((state) => {
-            const inventory = state.inventory.includes(item)
-              ? state.inventory
-              : [...state.inventory, item]
-
-            return { inventory }
-          })
-        },
-        removeInventoryItem: (item: string) => {
-          set((state) => ({
-            inventory: state.inventory.filter((entry) => entry !== item),
-          }))
-        },
-        setMastery: (mastery: MasteryRecord) => {
-          set({ mastery: normalizeMastery(mastery) })
-        },
-        recordMastery: (topic: string, correct: boolean) => {
-          if (typeof topic !== 'string' || topic.length === 0) {
-            return
-          }
-
-          set((state) => {
-            const current = state.mastery[topic] ?? { right: 0, wrong: 0 }
-            const next: MasteryStats = {
-              right: current.right + (correct ? 1 : 0),
-              wrong: current.wrong + (correct ? 0 : 1),
-            }
-
-            return {
-              mastery: {
-                ...state.mastery,
-                [topic]: next,
-              },
-            }
-          })
-        },
-        resetMastery: (topic?: string) => {
-          if (!topic) {
-            set({ mastery: {} })
-            return
-          }
-
-          set((state) => {
-            const next = { ...state.mastery }
-            delete next[topic]
-            return { mastery: next }
-          })
-        },
-        setStreakDays: (value: number) => {
-          set({ streakDays: Math.max(0, Math.round(value)) })
-        },
-        incrementStreak: () => {
-          set((state) => ({ streakDays: state.streakDays + 1 }))
-        },
-        resetStreak: () => {
-          set({ streakDays: 0 })
-        },
-        setHintsUsed: (value: number) => {
-          set({ hintsUsed: Math.max(0, Math.round(value)) })
-        },
-        incrementHintsUsed: () => {
-          set((state) => ({ hintsUsed: state.hintsUsed + 1 }))
-        },
-        resetHints: () => {
-          set({ hintsUsed: 0 })
-        },
-        createSnapshot: () => {
-          const state = get()
-          return {
-            day: state.day,
-            runId: state.runId,
-            runSeed: state.runSeed,
-            coins: state.coins,
-            xp: state.xp,
-            meters: { ...state.meters },
-            skills: [...state.skills],
-            badges: [...state.badges],
-            inventory: [...state.inventory],
-            mastery: Object.fromEntries(
-              Object.entries(state.mastery).map(([topic, stats]) => [topic, { ...stats }]),
-            ),
-            streakDays: state.streakDays,
-            hintsUsed: state.hintsUsed,
-          }
-        },
-        loadSnapshot: (snapshot: GameStateSnapshot) => {
-          applySnapshot(snapshot)
-        },
-        saveToStorage: () => {
-          if (!isBrowser) {
-            return false
-          }
-
-          try {
-            const snapshot = get().createSnapshot()
-            window.localStorage.setItem(BACKUP_KEY, JSON.stringify(snapshot))
-            return true
-          } catch (error) {
-            console.warn('Failed to save game snapshot', error)
-            return false
-          }
-        },
-        restoreFromStorage: () => {
-          if (!isBrowser) {
-            return false
-          }
-
-          const raw = window.localStorage.getItem(BACKUP_KEY)
-
-          if (!raw) {
-            return false
-          }
-
-          try {
-            const parsed = JSON.parse(raw) as GameStateSnapshot
-            applySnapshot(parsed)
-            return true
-          } catch (error) {
-            console.warn('Failed to restore game snapshot', error)
-            return false
-          }
+        mastery: {
+          ...state.mastery,
+          [topic]: next,
         },
       }
-    },
-    {
-      name: STORAGE_KEY,
-      version: 1,
-      partialize: (state) => {
-        const snapshot = {
-          day: state.day,
-          runId: state.runId,
-          runSeed: state.runSeed,
-          coins: state.coins,
-          xp: state.xp,
-          meters: state.meters,
-          skills: state.skills,
-          badges: state.badges,
-          inventory: state.inventory,
-          mastery: state.mastery,
-          streakDays: state.streakDays,
-          hintsUsed: state.hintsUsed,
-        }
+    })
+  },
+  resetMastery: (topic?: string) => {
+    if (!topic) {
+      setData({ mastery: {} })
+      return
+    }
 
-        return snapshot
-      },
-      onRehydrateStorage: () => (state) => {
-        if (state) {
-          try {
-            hydrateSnapshot?.(state as GameStateSnapshot)
-          } catch (error) {
-            console.warn('Failed to hydrate game state', error)
-            const fallback = createDefaultSnapshot()
-            hydrateSnapshot?.({ ...fallback, runId: createRunId() })
-          }
-        }
-      },
-    },
-  ),
-)
+    setData((state) => {
+      const next = { ...state.mastery }
+      delete next[topic]
+      return { mastery: next }
+    })
+  },
+  setStreakDays: (value: number) => {
+    setData({ streakDays: Math.max(0, Math.round(value)) })
+  },
+  incrementStreak: () => {
+    setData((state) => ({ streakDays: state.streakDays + 1 }))
+  },
+  resetStreak: () => {
+    setData({ streakDays: 0 })
+  },
+  setHintsUsed: (value: number) => {
+    setData({ hintsUsed: Math.max(0, Math.round(value)) })
+  },
+  incrementHintsUsed: () => {
+    setData((state) => ({ hintsUsed: state.hintsUsed + 1 }))
+  },
+  resetHints: () => {
+    setData({ hintsUsed: 0 })
+  },
+  createSnapshot: () => {
+    return createSnapshotFromData()
+  },
+  loadSnapshot: (snapshot: GameStateSnapshot) => {
+    applySnapshot(snapshot)
+  },
+  saveToStorage: () => {
+    if (!isBrowser) {
+      return false
+    }
+
+    try {
+      const snapshot = createSnapshotFromData()
+      window.localStorage.setItem(BACKUP_KEY, JSON.stringify(snapshot))
+      return true
+    } catch (error) {
+      console.warn('Failed to save game snapshot', error)
+      return false
+    }
+  },
+  restoreFromStorage: () => {
+    if (!isBrowser) {
+      return false
+    }
+
+    const raw = window.localStorage.getItem(BACKUP_KEY)
+
+    if (!raw) {
+      return false
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as GameStateSnapshot
+      applySnapshot(parsed)
+      return true
+    } catch (error) {
+      console.warn('Failed to restore game snapshot', error)
+      return false
+    }
+  },
+}
+
+const getValue = (): GameStateValue => ({ ...data, ...actions })
+
+const subscribe = (listener: () => void) => {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+if (isBrowser) {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as GameStateSnapshot
+      applySnapshot(parsed)
+    }
+  } catch (error) {
+    console.warn('Failed to hydrate game state', error)
+    const fallback = createDefaultSnapshot()
+    applySnapshot({ ...fallback, runId: createRunId() })
+  }
+}
+
+export function useGameState<T = GameStateValue>(selector?: (state: GameStateValue) => T): T {
+  const select = useCallback(
+    (state: GameStateValue) => (selector ? selector(state) : (state as unknown as T)),
+    [selector],
+  )
+  const getSnapshot = useCallback(() => select(getValue()), [select])
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+export const getGameState = (): GameStateValue => getValue()


### PR DESCRIPTION
## Summary
- replace the zustand-based game state store with a custom implementation powered by useSyncExternalStore
- preserve snapshot, persistence, and helper utilities while relying only on built-in browser and React APIs
- remove the zustand dependency from the project manifest

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d923dec2308320b06f72952b726b61